### PR TITLE
Load NetInfo via destructuring in Groceries

### DIFF
--- a/src/components/Groceries.js
+++ b/src/components/Groceries.js
@@ -2,11 +2,11 @@ const React = require('react-native')
 const {
   StyleSheet,
   ListView,
+  NetInfo,
   Text,
   TextInput,
   View
 } = React
-const NetInfo = React.NativeModules.NetInfo
 const Firebase = require('firebase')
 const config = require('../../config')
 const Item = require('./Item')


### PR DESCRIPTION
Not sure why it was loaded separately, but this broke for me when trying to run locally (specifically, `isConnected` on line 38 was undefined on `NetInfo`. Cheers.
